### PR TITLE
Set minimum jenkins version to 2.164.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <snakeyaml.version>1.26</snakeyaml.version>
     <java.level>8</java.level>
+    <jenkins.version>2.164.3</jenkins.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Hi I'm trying to bump the version of jcasc in the bom, but this is blocked on this plugin having a core dep of 2.204, in order to introduce this plugin to the bom it needs to have a version available on all supported lines,

we're dropping the 2.150 line which makes 2.164.x the minimum required line,

would you consider dropping your minimum so that this can be added to the bom and the jcasc plugin version can be increased there?

cc @escoem @amuniz 
https://github.com/jenkinsci/bom/pull/214

ref https://github.com/jenkinsci/bom/pull/214