### PR TITLE
Increase jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <snakeyaml.version>1.26</snakeyaml.version>
     <java.level>8</java.level>
-    <jenkins.version>2.164.3</jenkins.version>
+    <jenkins.version>2.204.6</jenkins.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Bump jenkins version up so there's no longer an implied dependency on trilead-api

ref: https://github.com/jenkinsci/snakeyaml-api-plugin/pull/1#issuecomment-614530404