### PR TITLE
Bump jenkins requirement from 2.204.6 to 2.289.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <snakeyaml.version>1.30</snakeyaml.version>
     <java.level>8</java.level>
-    <jenkins.version>2.204.6</jenkins.version>
+    <jenkins.version>2.289.3</jenkins.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This is to remove an implied dependency on `sshd` that can cause a dependency cycle. See https://github.com/jenkinsci/mina-sshd-api-plugin/pull/13.

Note: I chose 2.289.1 because I could not find when snakeyaml was split from Jenkins Core and `sshd` requires this version at the moment.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue