### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 11],
     [platform: 'linux', jdk: 17],
     [platform: 'linux', jdk: 21],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,6 @@ buildPlugin(
   useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 11],
-    [platform: 'linux', jdk: 17]
+    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 21],
 ])


### PR DESCRIPTION
## Test with Java 21

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

Java 11 will be unsupported by Eclipse Temurin and some other Java providers in October 2024. We'll need to move past Java 11 by that time. It does not change the supported Java version or the byte code that is being generated.

This includes Java 11 in the test configuration on the assumption that will be more palatable to the maintainers.  I believe Java 11 testing is already happening well enough without testing it in the CI job.  Java 11 byte code is being generated by the Java 17 and Java 21 compilation. Java 11 is being tested at least weekly by the plugin bill of materials.  If maintainers are willing to remove Java 11 from the test configuration, I am happy to make that change to this pull request.

### Testing done

Confirmed that tests pass with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
