### PR TITLE
Update parent POM, switch to Renovate, enable dep automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
----
-version: 2
-updates:
-  - package-ecosystem: maven
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>jenkins-infra/.github:renovate-config"
+  ]
+}

--- a/.github/workflows/auto-merge-safe-deps.yml
+++ b/.github/workflows/auto-merge-safe-deps.yml
@@ -1,0 +1,9 @@
+name: Automatically approve and merge safe dependency updates
+on:
+- pull_request_target
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge-safe-deps:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/auto-merge-safe-deps.yml@v1

--- a/.github/workflows/close-bom-if-passing.yml
+++ b/.github/workflows/close-bom-if-passing.yml
@@ -1,0 +1,11 @@
+name: Close BOM update PR if passing
+on:
+  check_run:
+    types:
+    - completed
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  close-bom-if-passing:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/close-bom-if-passing.yml@v1

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2108.v08c2b_01b_cf4d</version>
+    <version>6.2122.v70b_7b_f659d72</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
Ensures that we pick up https://github.com/jenkinsci/plugin-pom/pull/1290 despite https://github.com/dependabot/dependabot-core/issues/14102.

This PR updates the plugin to:
- Use the latest parent POM version (6.2122.v70b_7b_f659d72)
- Switch from Dependabot to Renovate for dependency management, as in https://github.com/jenkinsci/archetypes/pull/886
- (Perhaps) enable GitHub Actions reusable workflows for dependency automerge, as in https://github.com/jenkins-infra/github-reusable-workflows/pull/48

[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/BEE-66540)

🤖 Generated with [Claude Code](https://claude.com/claude-code)